### PR TITLE
Added scripts to generate hostfile mappings

### DIFF
--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
@@ -1,0 +1,36 @@
+# <copyright file="GenerateHostfileMappings.ps1" company="Microsoft Corporation">
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# </copyright>
+
+# Instructions:
+# 1. Login to the application server using root user credentials.
+# 2. Copy this file to the Desktop on the SAP system instance.
+# 3. Open powershell in the same directory and run the following command to execute the script:
+#    ./GenerateHostfileMappings.ps1 -instanceNumber <instance_number>
+# For example: ./GenerateHostfileMappings.ps1 -instanceNumber 00
+
+param(
+#[Parameter(Mandatory=$true)]]
+[int]$instanceNumber
+)
+
+# Set the path to the SAP hostctrl executable
+Set-Location -Path "C:\Program Files\SAP\hostctrl\exe"
+
+# Get the hostnames of the SAP system instance
+$hosts = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function GetSystemInstanceList | Select-String -Pattern "hostname" | ForEach-Object {$_.Line.Split()[2]}
+
+# Get the fully qualified domain name
+$fqdn = .\sapcontrol -prot NI_HTTP -nr $instanceNumber -format script -function ParameterValue | Select-String -Pattern "SAPFQDN" | ForEach-Object {$_.Line.Split("=")[1]}
+
+$hostfile_entries = New-Object System.Collections.Generic.HashSet[string]
+
+# Loop through each hostnames
+foreach ($hostname in $hosts) {
+    $ping = Test-Connection -ComputerName $hostname -Count 1
+    $ip = $ping.IPV4Address.IPAddressToString
+    $hostfile_entries.add("$ip" + " " + "$hostname" + ".$fqdn" + " " + "$hostname")
+}
+
+# Print the host file entries
+$hostfile_entries -join ", "

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.ps1
@@ -2,13 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # </copyright>
 
-# Instructions:
-# 1. Login to the application server using root user credentials.
-# 2. Copy this file to the Desktop on the SAP system instance.
-# 3. Open powershell in the same directory and run the following command to execute the script:
-#    ./GenerateHostfileMappings.ps1 -instanceNumber <instance_number>
-# For example: ./GenerateHostfileMappings.ps1 -instanceNumber 00
-
 param(
 #[Parameter(Mandatory=$true)]]
 [int]$instanceNumber

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
@@ -2,13 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # </copyright>
 
-# Instructions:
-# 1. Login to the application server using root user credentials.
-# 2. Copy this file to the home directory on the SAP system instance.
-# 3. Run the following command to execute the script: ./GenerateHostfileMappings.sh <instance_number>
-# For example: ./GenerateHostfileMappings.sh 00
-
-
 #!/bin/bash
 # Get instance number as a parameter
 instanceNumber=$1

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/GenerateHostfileMappings.sh
@@ -1,0 +1,37 @@
+# <copyright file="GenerateHostfileMappings.sh" company="Microsoft Corporation">
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# </copyright>
+
+# Instructions:
+# 1. Login to the application server using root user credentials.
+# 2. Copy this file to the home directory on the SAP system instance.
+# 3. Run the following command to execute the script: ./GenerateHostfileMappings.sh <instance_number>
+# For example: ./GenerateHostfileMappings.sh 00
+
+
+#!/bin/bash
+# Get instance number as a parameter
+instanceNumber=$1
+
+# Set the path to the SAP hostctrl executable
+cd "/usr/sap/hostctrl/exe"
+
+# Get the hostnames of the SAP system instance
+hosts=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function GetSystemInstanceList | grep "hostname" | cut -d " " -f 3)
+
+# Get the fully qualified domain name
+fqdn=$(./sapcontrol -prot PIPE -nr $instanceNumber -format script -function ParameterValue | grep "SAPFQDN" | cut -d "=" -f 2 | tr -d '\r')
+
+# Declare an array to store the host file entries
+hostfile_entries=()
+
+# Loop through each hostname
+for hostname in $hosts
+do
+    ip=$(ping -c 1 $hostname | head -n 1 | cut -d "(" -f 2 | cut -d ")" -f 1)
+    hostfile_entries+="$ip $hostname.$fqdn $hostname, "
+done
+
+# Print the host file entries separated by commas
+IFS=","
+echo "${hostfile_entries[*]}"

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
@@ -1,0 +1,21 @@
+## Generate hostfile mappings input for NetWeaver Provider in AMS
+
+### Windows Virtual Machines
+
+Steps:
+
+1. Login to the application server using root user credentials.
+2. Copy the "GenerateHostfileMappings.ps1" file to the Desktop on the SAP system instance.
+3. Open powershell in the same directory and run the following command to execute the script:
+```./GenerateHostfileMappings.ps1 -instanceNumber <instance_number>```
+For example: ./GenerateHostfileMappings.ps1 -instanceNumber 00
+
+### Windows Virtual Machines
+
+Steps:
+
+1. Login to the application server using root user credentials.
+2. Copy the "GenerateHostfileMappings.sh" file to the home directory on the SAP system instance.
+3. Run the following command to execute the script: 
+```./GenerateHostfileMappings.sh <instance_number>```
+For example: ./GenerateHostfileMappings.sh 00

--- a/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
+++ b/Provider_Pre_Requisites/SAP_NetWeaver_Pre_Requisites/GenerateHostfileMappings/README.MD
@@ -10,7 +10,7 @@ Steps:
 ```./GenerateHostfileMappings.ps1 -instanceNumber <instance_number>```
 For example: ./GenerateHostfileMappings.ps1 -instanceNumber 00
 
-### Windows Virtual Machines
+### Linux Virtual Machines
 
 Steps:
 


### PR DESCRIPTION
This PR consists of two scripts for Linux and Windows respectively. These scripts will help the AMS users to generate host file mappings in the correct format.